### PR TITLE
Bugfix: Toggle Obstacle

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,15 +68,12 @@ def draw_board(screen, board, last_click_time, current_state):
                         valid_click_occured = False
                         if current_state == State.CREATE_OBSTACLES:
                             cell.toggle_is_obstacle()
-                            cell.color = BLACK
                             valid_click_occured = True
                         elif current_state == State.CHOOSE_START and not cell.is_obstacle:
-                            cell.toggle_is_start_point()
-                            cell.color = RED
+                            cell.toggle_is_start_point()                            
                             valid_click_occured = True
                         elif current_state == State.CHOOSE_END and not cell.is_obstacle and not cell.is_start_point:
                             cell.toggle_is_end_point()
-                            cell.color = GREEN
                             valid_click_occured = True
                         # Check if a valid click on a cell occured and note the coordinates of the click
                         if valid_click_occured:

--- a/tile.py
+++ b/tile.py
@@ -15,12 +15,25 @@ class Tile:
 
     def toggle_is_start_point(self):
         self.is_start_point = not self.is_start_point
+        if self.is_start_point:
+            self.color = RED
+        else: 
+            self.color = WHITE
 
     def toggle_is_end_point(self):
         self.is_end_point = not self.is_end_point
+        if self.is_end_point:
+            self.color = GREEN
+        else: 
+            self.color = WHITE
+
 
     def toggle_is_obstacle(self):
         self.is_obstacle = not self.is_obstacle
+        if self.is_obstacle:
+            self.color = BLACK
+        else: 
+            self.color = WHITE
 
     def set_g(self, val):
         self.g = val


### PR DESCRIPTION
- Fixed obstacle tile not visually toggling off when clicked even though toggle ocurrs
- This bug was caused by the color being set to BLACK upon the tile initially being set as an obstacle so toggling it back wouldn't change the color back
- Fixed by moving color handling code into toggle function (did this for all status chanegs)